### PR TITLE
Replace greedy auto-tap heurestic with maximal bipartite matching

### DIFF
--- a/lib/src/bipartite.rs
+++ b/lib/src/bipartite.rs
@@ -1,0 +1,79 @@
+//! # Maximum bipartite matching implementation
+
+// Various resources for my own benefit
+// - https://github.com/mtgoncurve/landlord/issues/16
+// - https://www.youtube.com/watch?v=HZLKDC9OSaQ
+// - https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-042j-mathematics-for-computer-science-fall-2010/readings/MIT6_042JF10_chap05.pdf
+// - https://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm
+// - https://en.wikipedia.org/wiki/Hopcroft%E2%80%93Karp_algorithm
+// - https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm
+// - http://olympiad.cs.uct.ac.za/presentations/camp2_2017/bipartitematching-robin.pdf
+
+/// Returns the size of the maximum matching set of the
+/// bipartite graph represented by the adjacency matrix
+/// `edges` with `m_count` rows and `n_count` columns.
+/// `seen` and `matches` are implementation-specific data structures
+/// that are expected to be correctly sized by the caller to reduce
+/// runtime allocations.
+/// Implementation based on the "Alternate Approach" from
+/// http://olympiad.cs.uct.ac.za/presentations/camp2_2017/bipartitematching-robin.pdf
+pub fn maximum_bipartite_matching(
+    edges: &Vec<u8>,
+    m_count: usize,
+    n_count: usize,
+    seen: &mut Vec<bool>,
+    matches: &mut Vec<i32>,
+) -> usize {
+    let mut match_count = 0;
+    // reset matches
+    for mat in matches.iter_mut() {
+        *mat = -1;
+    }
+    // for each mana pip
+    for m in 0..m_count {
+        // reset lands seen
+        for s in seen.iter_mut() {
+            *s = false;
+        }
+        // Attempt to find a matching land
+        let found_match = recursive_find_match(edges, m_count, n_count, m, seen, matches);
+        if found_match {
+            match_count += 1;
+        }
+    }
+    match_count
+}
+
+fn recursive_find_match(
+    edges: &Vec<u8>,
+    m_count: usize,
+    n_count: usize,
+    m: usize,
+    seen: &mut Vec<bool>,
+    matches: &mut Vec<i32>,
+) -> bool {
+    // for each land
+    for n in 0..n_count {
+        let i = n_count * m + n;
+        // Is this the first time we're seeing this land and does this land pay for pip m?
+        if edges[i] != 0 && !seen[n] {
+            seen[n] = true;
+            // Is this land available to tap OR can we find a different land for pip (matches[n]) that
+            // previously matched with this land
+            let this_land_or_other_land_available = matches[n] < 0
+                || recursive_find_match(
+                    edges,
+                    m_count,
+                    n_count,
+                    matches[n] as usize,
+                    seen,
+                    matches,
+                );
+            if this_land_or_other_land_available {
+                matches[n] = m as i32;
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/lib/src/hand.rs
+++ b/lib/src/hand.rs
@@ -1133,4 +1133,28 @@ mod tests {
     assert_eq!(result.paid, true);
     assert_eq!(result.cmc, true);
   }
+
+  #[test]
+  fn test_issue_16() {
+    let mana_cost = ManaCost::from_rgbuwc(1, 1, 1, 2, 1, 0);
+    let card = Card {
+      mana_cost,
+      all_mana_costs: vec![mana_cost],
+      kind: CardKind::Creature,
+      turn: mana_cost.cmc(),
+      ..Default::default()
+    };
+    let h = vec![
+      card!("Temple of Enlightenment"), // {W}{U}
+      card!("Temple of Deceit"),        // {U}{B}
+      card!("Temple of Deceit"),        // {U}{B}
+      card!("Temple of Plenty"),        // {W}{G}
+      card!("Temple of Abandon"),       // {R}{G}
+      card!("Temple of Abandon"),       // {R}{G}
+    ];
+    let hand = Hand::from_opening_and_draws(&h, &[]);
+    let result = hand.play_cmc_auto_tap(&card);
+    assert_eq!(result.paid, true);
+    assert_eq!(result.cmc, true);
+  }
 }

--- a/lib/src/hand.rs
+++ b/lib/src/hand.rs
@@ -316,38 +316,37 @@ impl Hand {
     let u_range = b_range.end..(b_range.end + u_pips);
     let w_range = u_range.end..(u_range.end + w_pips);
     let c_range = w_range.end..(w_range.end + c_pips);
-    for (n, land) in scratch.lands.iter().enumerate() {
-      let r = std::cmp::min(1, land.mana_cost.r);
-      let g = std::cmp::min(1, land.mana_cost.g);
-      let b = std::cmp::min(1, land.mana_cost.b);
-      let w = std::cmp::min(1, land.mana_cost.w);
-      let u = std::cmp::min(1, land.mana_cost.u);
-      let c = 1; // All land cards can tap for colorless
-      for m in r_range.clone() {
-        let i = N * m + n;
-        scratch.edges[i] = r;
-      }
-      for m in g_range.clone() {
-        let i = N * m + n;
-        scratch.edges[i] = g;
-      }
-      for m in b_range.clone() {
-        let i = N * m + n;
-        scratch.edges[i] = b;
-      }
-      for m in u_range.clone() {
-        let i = N * m + n;
-        scratch.edges[i] = u;
-      }
-      for m in w_range.clone() {
-        let i = N * m + n;
-        scratch.edges[i] = w;
-      }
-      for m in c_range.clone() {
-        let i = N * m + n;
-        scratch.edges[i] = c;
+    for m in r_range {
+      for (n, land) in scratch.lands.iter().enumerate() {
+        scratch.edges[N * m + n] = std::cmp::min(1, land.mana_cost.r);
       }
     }
+    for m in g_range {
+      for (n, land) in scratch.lands.iter().enumerate() {
+        scratch.edges[N * m + n] = std::cmp::min(1, land.mana_cost.g);
+      }
+    }
+    for m in b_range {
+      for (n, land) in scratch.lands.iter().enumerate() {
+        scratch.edges[N * m + n] = std::cmp::min(1, land.mana_cost.b);
+      }
+    }
+    for m in u_range {
+      for (n, land) in scratch.lands.iter().enumerate() {
+        scratch.edges[N * m + n] = std::cmp::min(1, land.mana_cost.u);
+      }
+    }
+    for m in w_range {
+      for (n, land) in scratch.lands.iter().enumerate() {
+        scratch.edges[N * m + n] = std::cmp::min(1, land.mana_cost.w);
+      }
+    }
+    for m in c_range {
+      for (n, _) in scratch.lands.iter().enumerate() {
+        scratch.edges[N * m + n] = 1;
+      }
+    }
+
     let result = bipartite_maximum_matches(
       &scratch.edges,
       M,
@@ -355,11 +354,9 @@ impl Hand {
       &mut scratch.seen,
       &mut scratch.matches,
     );
-    let paid = result == M;
-    let cmc = scratch.lands.len() >= goal.mana_cost.cmc() as usize;
     AutoTapResult {
-      paid,
-      cmc,
+      paid: result == M,
+      cmc: true,
       in_opening_hand,
       in_draw_hand,
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -23,6 +23,7 @@ pub mod arena;
 pub mod card;
 #[macro_use]
 pub mod deck;
+mod bipartite;
 pub mod collection;
 pub mod data;
 pub mod hand;

--- a/lib/src/simulation.rs
+++ b/lib/src/simulation.rs
@@ -1,7 +1,7 @@
 //! # Simulation engine and card observations
 use crate::card::Card;
 use crate::deck::Deck;
-use crate::hand::{AutoTapResult, Hand, PlayOrder, SimCard};
+use crate::hand::{AutoTapResult, Hand, PlayOrder, Scratch, SimCard};
 use crate::mulligan::Mulligan;
 use rand::prelude::*;
 use rand::rngs::SmallRng;
@@ -77,7 +77,7 @@ impl Simulation {
   pub fn observations_for_card_by_turn(&self, card: &Card, turn: usize) -> Observations {
     let mut observations = Observations::new();
     observations.total_runs = self.hands.len();
-    let mut scratch = Vec::with_capacity(self.hands[0].len());
+    let mut scratch = Scratch::new(30, 10);
     let play_order = if self.on_the_play {
       PlayOrder::First
     } else {


### PR DESCRIPTION
This commit replaces the incorrect greedy auto-tap heuristic with an algorithm to solve for the size of the maximum bipartite matching set, where the bipartite graph is composed of the mana pips of the goal card and the land cards in hand.

Adds a test case for the counterexample proposed in #16

Closes #16 