### PR TITLE
[IKO] Use scryfall-oracle-cards.json again

### DIFF
--- a/bins/card-update.sh
+++ b/bins/card-update.sh
@@ -2,7 +2,7 @@
 set -x
 
 DATE=$(date "+%Y-%m-%d")
-ALL_FILE="scryfall-default-cards"
+ALL_FILE="scryfall-oracle-cards"
 ALL_INPUT="$ALL_FILE-$DATE.json"
 CI=${LANDLORD_IS_CI:-0}
 

--- a/bins/scryfall2landlord/src/main.rs
+++ b/bins/scryfall2landlord/src/main.rs
@@ -56,6 +56,20 @@ fn main() -> Result<(), Error> {
     let json_val = serde_json::from_str(&json_file_contents)?;
     info!("Deserializing Scryfall JSON");
     let mut scryfall_cards: Vec<ScryfallCard> = serde_json::from_value(json_val)?;
+    // Filter out any cards that are not legal in all formats
+    // This should filter out any tokens
+    // See https://github.com/mtgoncurve/landlord/issues/4
+    scryfall_cards = scryfall_cards
+        .into_iter()
+        .filter(|c| !c.legalities.values().all(|l| l == &Legality::NotLegal))
+        .collect();
+    /*
+    // TODO(jshrake):
+    // The following commented out code attempts to whittle down the defaul cards
+    // file from https://scryfall.com/docs/api/bulk-data so that it's similar to
+    // the oracle cards file. This is useful when the oracle cards file is missing
+    // cards from future sets.  Reconsider making this code more robust at a later time.
+    //
     // Filter out non-english cards
     scryfall_cards = scryfall_cards
         .into_iter()
@@ -68,15 +82,9 @@ fn main() -> Result<(), Error> {
         .into_iter()
         .filter(|c| c.set_type != "funny")
         .collect();
-    // Filter out any cards that are not legal in all formats
-    // This should filter out any tokens
-    // See https://github.com/mtgoncurve/landlord/issues/4
-    scryfall_cards = scryfall_cards
-        .into_iter()
-        .filter(|c| !c.legalities.values().all(|l| l == &Legality::NotLegal))
-        .collect();
     scryfall_cards.sort_by_cached_key(|c| (c.oracle_id.clone(), std::cmp::Reverse(c.released_at)));
     scryfall_cards.dedup_by_key(|c| c.oracle_id.clone());
+    */
     // Flatten the card_faces out into scryfall_cards
     // To do that, we clone and update the image_uris to that of the parent card
     let mut card_faces = Vec::with_capacity(500);

--- a/data/all_cards.landlord
+++ b/data/all_cards.landlord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e85ea1c02d93ac8ba5e429626bd82cccfeb7e2387f483a4960272d23a2b9bb9
+oid sha256:0a543f50f86dca59a06ff145a92d20f0bf0208d0d49510fe046969b9e2a8c026
 size 3317982

--- a/lib/src/card/card.rs
+++ b/lib/src/card/card.rs
@@ -615,4 +615,11 @@ mod tests {
         assert_eq!(card.is_land(), false);
         assert_eq!(card.kind, CardKind::Unknown);
     }
+
+    #[test]
+    fn card_nexus_of_fate() {
+        let card = card!("Nexus of Fate");
+        assert_eq!(card.is_land(), false);
+        assert_eq!(card.kind, CardKind::Unknown);
+    }
 }


### PR DESCRIPTION
Unfortunately, this does not change the WASM file footprint (see #18).

Closes #19