### PR TITLE
Add support for treating taplands as etb tapped

### DIFF
--- a/lib/src/card/card.rs
+++ b/lib/src/card/card.rs
@@ -120,6 +120,14 @@ impl CardKind {
             || self == Self::OtherLand
             || self == Self::ForcedLand
     }
+
+    #[inline]
+    pub fn untapped(self, just_drew: bool) -> bool {
+        if !just_drew {
+            return true;
+        }
+        return self != CardKind::TapLand
+    }
 }
 
 #[macro_export]
@@ -1085,5 +1093,21 @@ mod tests {
         let card = card!("Yarus, Roar of the Old Gods");
         assert_eq!(card.is_land(), false);
         assert_eq!(card.kind, CardKind::Unknown);
+    }
+
+    #[test]
+    fn untapped_0() {
+        let card = card!("Coastal Tower");
+        assert!(card.is_land());
+        assert!(!card.kind.untapped(true));
+        assert!(card.kind.untapped(false));
+    }
+
+    #[test]
+    fn untapped_1() {
+        let card = card!("Tundra");
+        assert!(card.is_land());
+        assert!(card.kind.untapped(true));
+        assert!(card.kind.untapped(false));
     }
 }

--- a/lib/src/mtgoncurve.rs
+++ b/lib/src/mtgoncurve.rs
@@ -448,7 +448,7 @@ mod tests {
         1 Hydroid Krasis#X=23
         12 Island
         12 Forest
-        1 Memorial to Folly
+        1 Swamp
         ";
         let n = 1000;
         let input = Input {
@@ -987,7 +987,7 @@ Deck
 1 Davriel, Rogue Shadowmage (WAR) 83
 4 Nightmare Shepherd (THB) 108
 4 Gray Merchant of Asphodel (THB) 99
-4 Temple of Malice (THB) 247
+4 Blood Crypt
 4 Forest
 1 Mountain (ELD) 262
 11 Swamp (ELD) 258


### PR DESCRIPTION
This only handles truly tapped lands for now. Checklands and other types of conditionally tapped lands to be handled in a follow up PR.

Definitely interested on any feedback on my approach here – just kind of chucking stuff at a wall for now!

(My ultimate goal here is to support tapped lands, checklands and snarls with maybe some other stuff so I can use landlord as the basis for a manabase suggester for the Penny Dreadful format.)